### PR TITLE
Version Update

### DIFF
--- a/io.exodus.Exodus.appdata.xml
+++ b/io.exodus.Exodus.appdata.xml
@@ -21,7 +21,7 @@
     <category>Utility</category>
   </categories>
   <releases>
-    <release date="2019-02-05" version="19.2.5"/>
+    <release date="2019-04-26" version="19.4.26"/>
   </releases>
   <update_contact>tingping_at_fedoraproject.org</update_contact>
 </component>

--- a/io.exodus.Exodus.json
+++ b/io.exodus.Exodus.json
@@ -46,9 +46,9 @@
         },
         {
           "type": "extra-data",
-          "url": "https://exodusbin.azureedge.net/releases/exodus-linux-x64-19.2.5.zip",
-          "sha256": "f298d75a7974b505ead8ae08599ad943b5ac93ea69a05312a50a79a74d58dafd",
-          "size": 77609783,
+          "url": "https://exodusbin.azureedge.net/releases/exodus-linux-x64-19.4.26.zip",
+          "sha256": "d54f7133eecb620e1550ff967bddf6150fa3fba9de21058fea5079fb54005905",
+          "size": 77948901,
           "filename": "exodus.zip"
         },
         {


### PR DESCRIPTION
Updated to the latest version of Exodus Wallet "19.4.26" by changing the date and version line in io.exodus.Exodus.appdata.xml file and the URL, sha256sum, and size line in the io.exodus.Exodus.json file.