### PR TITLE
Update to Version 19.5.10

### DIFF
--- a/io.exodus.Exodus.appdata.xml
+++ b/io.exodus.Exodus.appdata.xml
@@ -21,7 +21,7 @@
     <category>Utility</category>
   </categories>
   <releases>
-    <release date="2019-04-26" version="19.4.26"/>
+    <release date="2019-05-10" version="19.5.10"/>
   </releases>
   <update_contact>tingping_at_fedoraproject.org</update_contact>
 </component>

--- a/io.exodus.Exodus.json
+++ b/io.exodus.Exodus.json
@@ -46,9 +46,9 @@
         },
         {
           "type": "extra-data",
-          "url": "https://exodusbin.azureedge.net/releases/exodus-linux-x64-19.4.26.zip",
-          "sha256": "d54f7133eecb620e1550ff967bddf6150fa3fba9de21058fea5079fb54005905",
-          "size": 77948901,
+          "url": "https://exodusbin.azureedge.net/releases/exodus-linux-x64-19.5.10.zip",
+          "sha256": "9d3c24fd9d7024a4912973c0f5e26f65fd98d736ddf3581bde53aed1e9fbf69f",
+          "size": 101749095,
           "filename": "exodus.zip"
         },
         {


### PR DESCRIPTION
Updated to the latest version of Exodus Wallet "19.5.10" by changing the date and version line in io.exodus.Exodus.appdata.xml file and the URL, sha256sum, and size line in the io.exodus.Exodus.json file.