### PR TITLE
Version Update & Broken Link Fix

### DIFF
--- a/io.exodus.Exodus.appdata.xml
+++ b/io.exodus.Exodus.appdata.xml
@@ -21,7 +21,7 @@
     <category>Utility</category>
   </categories>
   <releases>
-    <release date="2019-05-10" version="19.5.10"/>
+    <release date="2019-05-24" version="19.5.24"/>
   </releases>
   <update_contact>tingping_at_fedoraproject.org</update_contact>
 </component>

--- a/io.exodus.Exodus.appdata.xml
+++ b/io.exodus.Exodus.appdata.xml
@@ -13,9 +13,9 @@
   <project_license>LicenseRef-proprietary</project_license>
   <url type="homepage">https://www.exodus.io/</url>
   <screenshots>
-    <screenshot type="default">https://www.exodus.io/img/exodus-portfolio-2017-08@2x.jpg</screenshot>
-    <screenshot>https://www.exodus.io/img/exodus-exchange-aurora-ss@2x.jpg</screenshot>
-    <screenshot>https://www.exodus.io/img/exodus-wallet-btc@2x.jpg</screenshot>
+    <screenshot type="default">https://www.exodus.io/download/images/portfolio.png</screenshot>
+    <screenshot>https://www.exodus.io/download/images/exchange.png</screenshot>
+    <screenshot>https://www.exodus.io/download/images/wallet.png</screenshot>
   </screenshots>
   <categories>
     <category>Utility</category>

--- a/io.exodus.Exodus.json
+++ b/io.exodus.Exodus.json
@@ -46,9 +46,9 @@
         },
         {
           "type": "extra-data",
-          "url": "https://exodusbin.azureedge.net/releases/exodus-linux-x64-19.5.10.zip",
-          "sha256": "9d3c24fd9d7024a4912973c0f5e26f65fd98d736ddf3581bde53aed1e9fbf69f",
-          "size": 101749095,
+          "url": "https://exodusbin.azureedge.net/releases/exodus-linux-x64-19.5.24.zip",
+          "sha256": "bc61dd1639a30c17010dd83394ad11e839f7e2e96a0b8720be151751a249a2fb",
+          "size": 101775963,
           "filename": "exodus.zip"
         },
         {


### PR DESCRIPTION
Updated to the latest version of Exodus Wallet "19.5.24" by changing the date and version line in io.exodus.Exodus.appdata.xml file and the URL, sha256sum, and size line in the io.exodus.Exodus.json file.  Also fixed the broken screenshot links in the io.exodus.Exodus.appdata.xml file.