### PR TITLE
Version Update 19.6.6

### DIFF
--- a/io.exodus.Exodus.appdata.xml
+++ b/io.exodus.Exodus.appdata.xml
@@ -21,7 +21,7 @@
     <category>Utility</category>
   </categories>
   <releases>
-    <release date="2019-05-24" version="19.5.24"/>
+    <release date="2019-06-06" version="19.6.6"/>
   </releases>
   <update_contact>tingping_at_fedoraproject.org</update_contact>
   <content_rating type="oars-1.1" />

--- a/io.exodus.Exodus.json
+++ b/io.exodus.Exodus.json
@@ -46,9 +46,9 @@
         },
         {
           "type": "extra-data",
-          "url": "https://exodusbin.azureedge.net/releases/exodus-linux-x64-19.5.24.zip",
-          "sha256": "bc61dd1639a30c17010dd83394ad11e839f7e2e96a0b8720be151751a249a2fb",
-          "size": 101775963,
+          "url": "https://exodusbin.azureedge.net/releases/exodus-linux-x64-19.6.6.zip",
+          "sha256": "8fe4d8a4b6e5feaef58b3cf2ec631247cd145e4872ae3bacec47d5ae0619f8e7",
+          "size": 106211333,
           "filename": "exodus.zip"
         },
         {


### PR DESCRIPTION
Updated to the latest version of Exodus Wallet "19.6.6" by changing the date and version line in io.exodus.Exodus.appdata.xml file and the URL, sha256sum, and size line in the io.exodus.Exodus.json file.