### PR TITLE
Update to Version 19.6.12 & Fixed Broken Image Links 

### DIFF
--- a/io.exodus.Exodus.appdata.xml
+++ b/io.exodus.Exodus.appdata.xml
@@ -13,15 +13,14 @@
   <project_license>LicenseRef-proprietary</project_license>
   <url type="homepage">https://www.exodus.io/</url>
   <screenshots>
-    <screenshot type="default">https://www.exodus.io/download/images/portfolio.png</screenshot>
-    <screenshot>https://www.exodus.io/download/images/exchange.png</screenshot>
-    <screenshot>https://www.exodus.io/download/images/wallet.png</screenshot>
+    <screenshot type="default">https://www.exodus.io/img/desktop-app.png</screenshot>
+    <screenshot>https://www.exodus.io/img/fb-meta-rect.png</screenshot>
   </screenshots>
   <categories>
     <category>Utility</category>
   </categories>
   <releases>
-    <release date="2019-06-06" version="19.6.6"/>
+    <release date="2019-06-12" version="19.6.12"/>
   </releases>
   <update_contact>tingping_at_fedoraproject.org</update_contact>
   <content_rating type="oars-1.1" />

--- a/io.exodus.Exodus.json
+++ b/io.exodus.Exodus.json
@@ -46,9 +46,9 @@
         },
         {
           "type": "extra-data",
-          "url": "https://exodusbin.azureedge.net/releases/exodus-linux-x64-19.6.6.zip",
-          "sha256": "8fe4d8a4b6e5feaef58b3cf2ec631247cd145e4872ae3bacec47d5ae0619f8e7",
-          "size": 106211333,
+          "url": "https://exodusbin.azureedge.net/releases/exodus-linux-x64-19.6.12.zip",
+          "sha256": "ab9141523de659ac7c1d692cd4e9eb4efeb52a1fa00d2d10f46781ef39f49938",
+          "size": 106211881,
           "filename": "exodus.zip"
         },
         {


### PR DESCRIPTION
Updated to the latest version of Exodus Wallet "19.6.12" by changing the date and version line in io.exodus.Exodus.appdata.xml file and the URL, sha256sum, and size line in the io.exodus.Exodus.json file. Also fixed the broken screenshot links and removed one of the three screenshot links in the .xml file.