### PR TITLE
Update exodus to 19.10.18

### DIFF
--- a/io.exodus.Exodus.appdata.xml
+++ b/io.exodus.Exodus.appdata.xml
@@ -21,7 +21,7 @@
     <category>Utility</category>
   </categories>
   <releases>
-    <release date="2019-09-27" version="19.9.27"/>
+    <release date="2019-10-18" version="19.10.18"/>
   </releases>
   <update_contact>tingping_at_fedoraproject.org</update_contact>
   <content_rating type="oars-1.1" />

--- a/io.exodus.Exodus.json
+++ b/io.exodus.Exodus.json
@@ -53,7 +53,8 @@
           "type": "script",
           "dest-filename": "exodus",
           "commands": [
-            "exec env TMPDIR=$XDG_CACHE_HOME /app/extra/Exodus $@"
+	    "export TMPDIR=\"$XDG_RUNTIME_DIR/app/$FLATPAK_ID\"",
+            "exec zypak-wrapper /app/extra/Exodus \"$@\""
           ]
         },
         {

--- a/io.exodus.Exodus.json
+++ b/io.exodus.Exodus.json
@@ -17,6 +17,16 @@
     "--device=dri"
   ],
   "modules": [
+  {
+    "name": "zypak",
+    "sources": [
+      {
+        "type": "git",
+        "url": "https://github.com/refi64/zypak",
+        "tag": "v2020.02"
+      }
+      ]
+    },
     {
       "name": "exodus",
       "buildsystem": "simple",

--- a/io.exodus.Exodus.json
+++ b/io.exodus.Exodus.json
@@ -48,9 +48,9 @@
         },
         {
           "type": "extra-data",
-          "url": "https://exodusbin.azureedge.net/releases/exodus-linux-x64-19.9.27.zip",
-          "sha256": "9f794ff4926af1f8aa551bc2e40d2c4da44507236663c5d9ac745547be152408",
-          "size": 82808489,
+          "url": "https://downloads.exodus.io/releases/exodus-linux-x64-19.10.18.zip",
+          "sha256": "08b1fdf741da482138a7d5e5be4ec473d8f81864b723873ff88e551b17a8bb20",
+          "size": 86752547,
           "filename": "exodus.zip"
         },
         {


### PR DESCRIPTION
Current version in flathub is two versions old.  Update to latest 19.10.18 released on Oct 18