### PR TITLE
fix(apply_extra): fix extraction

### DIFF
--- a/io.exodus.Exodus.json
+++ b/io.exodus.Exodus.json
@@ -37,8 +37,7 @@
                     "dest-filename": "apply_extra",
                     "commands": [
                         "unzip exodus.zip > /dev/null",
-                        "mv Exodus-linux-x64/* .",
-                        "rm -r Exodus-linux-x64 *.zip"
+                        "rm -r *.zip"
                     ]
                 },
                 {


### PR DESCRIPTION
Upstream has removed the root folder from the zip archive.

Fixes: #177