### PR TITLE
Make Exodus use wayland socket by default

### DIFF
--- a/io.exodus.Exodus.json
+++ b/io.exodus.Exodus.json
@@ -13,7 +13,8 @@
     "finish-args": [
         "--share=ipc",
         "--share=network",
-        "--socket=x11",
+        "--socket=wayland",
+        "--socket=fallback-x11",
         "--socket=pulseaudio",
         "--device=dri"
     ],


### PR DESCRIPTION
Exodus stopped working for me with an error saying that a wayland socket could not be opened. Changing the permissions to socket=wayland solves this, but the manifest specifies x11 only. Followed the Flatpak building guides, installed from my fork, seems to fix it. Let me know if I got something wrong, thanks in advance.